### PR TITLE
Allow extensions being implemented in types directly

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
@@ -600,6 +600,7 @@ public class DefaultErrorMessages {
                                              "\nLooked for this extension in:" +
                                              "\n" +
                                              "\n- Parameters of the caller function." +
+                                             "\n- Subtype of the type to resolve." +
                                              "\n- Companion object for the type to resolve." +
                                              "\n- Companion object for the contract interface." +
                                              "\n- Subpackages of the type to resolve." +

--- a/compiler/frontend/src/org/jetbrains/kotlin/extensionresolution/ExtensionResolution.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/extensionresolution/ExtensionResolution.kt
@@ -78,6 +78,39 @@ sealed class ExtensionResolution {
         }
     }
 
+
+    object FindInType : ExtensionResolution() {
+        override fun resolve(
+            lookingFor: ValueParameterDescriptor,
+            parameters: List<ValueParameterDescriptor>,
+            argumentParameterDescriptor: ValueParameterDescriptor,
+            substitutions: List<TypeSubstitution>,
+            lookInSupertypes: Boolean
+        ): ExtensionCandidateResolution {
+            val arguments = lookingFor.returnType!!.arguments
+            val error = Unresolved(
+                "Unable to resolve extension value inside type for argument " +
+                        "${argumentParameterDescriptor.name} : ${argumentParameterDescriptor.returnType}."
+            )
+
+            for (projection in arguments) {
+                val result = getCompatibleClasses(
+                    lookingFor,
+                    projection.type.memberScope,
+                    substitutions,
+                    lookInSupertypes
+                )
+
+                return when (result.candidates.size) {
+                    1 -> Resolved(SingleClassCandidate(result.candidates[0], result.substitutions))
+                    else -> error
+                }
+            }
+
+            return error
+        }
+    }
+
     object FindInTypeCompanion : ExtensionResolution() {
         override fun resolve(
             lookingFor: ValueParameterDescriptor,

--- a/compiler/frontend/src/org/jetbrains/kotlin/extensionresolution/ExtensionResolutionStrategy.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/extensionresolution/ExtensionResolutionStrategy.kt
@@ -24,6 +24,7 @@ object ExtensionResolutionStrategy {
         val functionOrder = listOf(
             FindInLocalFunction,
             FindInPackage,
+            FindInType,
             FindInTypeCompanion,
             FindInContractInterfaceCompanion,
             FindInTypeSubpackages,

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/IdeErrorMessages.java
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/IdeErrorMessages.java
@@ -190,6 +190,7 @@ public class IdeErrorMessages {
         MAP.put(UNABLE_TO_RESOLVE_EXTENSION, "<html>''{0}''<p>Looked for this extension in:</p>" +
                                              "<ul>" +
                                              "<li>Parameters of the caller function.</li>" +
+                                             "<li>Subtype of the type to resolve.</li>" +
                                              "<li>Companion object for the type to resolve.</li>" +
                                              "<li>Companion object for the contract interface.</li>" +
                                              "<li>Subpackages of the type to resolve.</li>" +


### PR DESCRIPTION
This implementation should show, how being able to define extension objects directly in the type itself could look like. 

Instead of 

```kotlin
class TypeA {
    companion object {
        extension object TypeAExtensions { }
    }
}
```

one can now simply write:

```kotlin
class TypeA {
    extension object TypeAExtensions { }
}
```
which feels more natural, since there are no obvious reasons for the `companion object` constraint. 


<br>

*This PR just serves as demo and playground for furhter discussion*

A feature like this would also require to check the visibility of the extension itself. 
Currently, the following code would compile, but crash at runtime:

```kotlin
interface SomeExtensions<T> {
    fun greet()
}

class TypeA {
    private extension object TypeAExtensions: SomeExtensions<TypeA> {
        override fun greet() = println("Hello")
    }
}

fun <T> T.greet(with extensions: SomeExtensions<T>) {
    greet()
}

fun main() {
    TypeA().greet()
}

```

Potential solutions: 
- Adjust `ExtensionResolution.FindInType` to ignore extensions with "non suitable" visibility (like it ignores non internal extensions for `ExtensionResolution.FindInPackage`
- Prevent compiling of subtype extension implementations that have "non suitable" visibility.


